### PR TITLE
feat: nix flakes and direnv support added

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+nix_direnv_manual_reload
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.swp
 *.pyc
-
+.venv/
 *.egg-info/
 dist/

--- a/README.md
+++ b/README.md
@@ -85,6 +85,69 @@ dependency versions from `constraints.txt`:
 pip install -e .[development] -c constraints.txt
 ```
 
+#### Nix Support
+
+You can also automatically build and create deployment envrionments and nix
+packages for nix with the `flake.nix` in the repository.  
+
+#### Installation of Nix Tooling
+To learn how to install nix on your systems [see here](https://nix.dev/install-nix.html)
+
+Once you have nix working on your system make sure to [enable flakes](https://nixos.wiki/wiki/Flakes)
+
+If you'd like to leverage the automatic development environment setup, install [direnv](https://github.com/nix-community/nix-direnv)
+
+If you use `direnv`, once it is installed and hooked into your shell, make sure to allow the
+``.envrc` file to turn on automatic shell creation and descruction.
+
+#### Development Environments
+Once you've cloned the `undertale` repo, in that directory you can easily enter a
+developer shell by running:
+
+```bash
+nix develop
+```
+This may take a while if you've never built anything before.
+
+You will automatically have all of the included development tools in scope as well as all 
+of the python dependencies in your python environment.  To exit the shell, run the `exit`
+command or hit control-D.
+
+#### Nix Packaging options
+If you'd just want to export or package, you can build the package as 
+
+```bash
+nix build
+```
+
+which will build undertale as a nix package and generate a symlink in the current directory
+called `result` pointing to the build entry in `/nix/store`
+
+Additionally, you can also build a package containing all of the environment depenencies for
+`undertale` by running
+
+```bash
+nix build .#undertale-environment
+```
+
+You can also create singularity or docker containers with a full isolated and built
+environment by calling the respective commands:
+
+```bash
+nix build .#singularity-image
+```
+
+or
+
+```bash
+nix build .#docker-image
+```
+
+which will create a `result` symlink in the current directory pointing to the respective image
+binaries.  Since they contain all dependencies, they are quite large tar.gz/sif files (>1GB)
+but the docker image is layered, so upon deployment will minimally occupy space as incremental
+versions are added.
+
 ### Code Style
 
 Pre-commit hooks are available for automatic code formatting, linting, and type

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1732109611,
+        "narHash": "sha256-x78cq+snot+gM+JScQgIV7QeEH5mVcdjdoOgfXVo24w=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "55201d64687824ffe7dd98b622bfae87d01a568b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,167 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    pyproject-nix = {
+      url = "github:nix-community/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    pyproject-nix,
+    ...
+  }: let
+      ## List of nixpkgs used in our development environment
+      developmentPackages = pkgs:
+        (with pkgs; [
+          gitFull
+          pre-commit
+          lazygit
+          sqlite
+          ghidra
+          singularity
+          fish
+          ncurses
+          which
+          stdenv
+          curl
+        ]);
+      libraryDependencies = pkgs:
+        (with pkgs; [
+          stdenv.cc.cc
+          gcc-unwrapped
+          glibc
+          glib
+          openssl
+          libpng
+          dbus
+          zstd
+        ]);
+      ## Lists of OS platform architectures and oses we support
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      ## Helper functions
+      ### function to create an attrset for all supported systems given a fn of the system
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+      ### an attrset mapping nix systems to their nixpkgs attrset
+      allPkgs = forAllSystems (system: nixpkgs.legacyPackages.${system});
+  in {
+    # define available nixpkgs exposed by this flake
+    packages = forAllSystems (system: let
+      pkgs = allPkgs.${system};
+      python = pkgs.python310.override {
+        # overriding custom nixpkgs python modules
+        self = pkgs.python310;
+        packageOverrides = final: prev: {
+          # pre-commit in nixpkgs is an application, not a module, but it's really both
+          pre-commit = final.toPythonModule pkgs.pre-commit;
+        };
+      };
+
+      # define the python project and read constraints
+      undertaleProject = pyproject-nix.lib.project.loadRequirementsTxt {
+        projectRoot = ./.;
+        requirements = pkgs.lib.readFile ./constraints.txt;
+      };
+
+      undertalePkgDeps = undertaleProject.renderers.withPackages { inherit python; };
+
+      undertaleConstraintErrors = undertaleProject.validators.validateVersionConstraints {
+        inherit python;
+      };
+
+      validatedConstraints = (pkgs.lib.debug.traceValSeq undertaleConstraintErrors) == {};
+
+      undertalePkgEnv = python.withPackages (undertalePkgDeps);
+    in {
+      default = self.packages.${system}.undertale-venv;
+
+      # NOTE: Currently not validating constraint matching because nix python packages lag slightly on several packages, but not apparently in a critical way.  will address as needed.  use package undertale-strict if you want to enforce version freezes
+
+      # export python environments containing all undertale python dependancies
+      undertale-environment =  undertalePkgEnv;
+      undertale-environment-strict = assert validatedConstraints; undertalePkgEnv;
+
+      #export a nixpkg for the undertale python package itself
+      # NOTE: should we compute just the non-development requirements in the environment
+      undertale = python.pkgs.buildPythonPackage {
+        name = "undertale";
+        src = ./.;
+        propagatedBuildInputs = [ undertalePkgEnv ];
+      };
+
+      undertale-strict = assert validatedConstraints; self.packages.${system}.undertale;
+
+      ## Defines a buildable singularity image containing devtools and dependencies
+      singularity-image = pkgs.singularity-tools.buildImage {
+        name = "undertale";
+        memSize = 2048;
+        diskSize = 15000;
+        contents = [ undertalePkgEnv ]
+          ++ (with pkgs; [ 
+            bat
+            helix
+            stdenv
+          ]) 
+          ++ (developmentPackages pkgs);
+      };
+
+      ## Defines a docker image containing this build of undertale and it's dependencies
+      docker-image = pkgs.dockerTools.buildLayeredImage (let
+        pkgsLinux = allPkgs."x86_64-linux";
+        pkgsSelf = self.packages."x86_64-linux";
+      in  {
+        name = "undertale";
+        tag = "latest";
+        contents = [ pkgsSelf.undertale ] ++ (developmentPackages pkgsLinux);
+        config = {
+          Cmd = "${pkgsSelf.undertale-environment}/bin/python3";
+        };
+      });
+    });
+
+    # define available developer shells exposed by this flake
+    devShells = forAllSystems (system:
+    let
+      pkgs = allPkgs.${system};
+      python = pkgs.python310;
+      wrappedPython = (pkgs.writeShellScriptBin "python" ''
+        export LD_LIBRARY_PATH=$NIX_LD_LIBRARY_PATH
+        SCRIPT_DIR=$(${pkgs.coreutils}/bin/dirname $(${pkgs.coreutils}/bin/realpath -s "$0"))
+        exec -a "$SCRIPT_DIR/python" "${python}/bin/python" "$@"
+      '');
+      venvDir = "./.venv";
+    in rec {
+        default = undertale-venv;
+        undertale-pkg = pkgs.mkShell {
+          packages = [ 
+            self.packages.${system}.undertale-environment
+          ] ++ (developmentPackages pkgs);
+        };
+        undertale-venv = pkgs.mkShell {
+          NIX_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath (libraryDependencies pkgs);
+          packages = (developmentPackages pkgs) ++ (libraryDependencies pkgs);
+          buildInputs = [
+            wrappedPython
+          ] ++ (libraryDependencies pkgs);
+          shellHook = ''
+            SOURCE_DATE_EPOCH=$(date +%s)
+
+            if [ -d ${venvDir} ]; then
+              echo "${venvDir} already exists, skipping venv creation"
+            else
+              echo "Creating new venv environment in ${venvDir}"
+              ${wrappedPython}/bin/python -m venv "${venvDir}"
+            fi
+
+            source "${venvDir}/bin/activate"
+
+            #fancy pipe tricks because pip is too verbose
+            set -o pipefail; pip install -r constraints.txt | { grep -v "already satisfied" || :; }
+          '';
+        };
+      }
+    );
+  };
+}


### PR DESCRIPTION
> added nix flake file with an initial set of dependencies for python and non-python packages, as well as build generators for a singularity environment and a nix package of the undertale repo itself for easy deployment and packaging

Closes #12 

To Do:
- [ ] resolve permissions issues identified on the old version of this issue.