### PR TITLE
ci: update actions worker to `ubuntu-latest`

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   Lint:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Check Title


### PR DESCRIPTION
updates the GitHub Actions worker to work with public GitHub