### PR TITLE
chore: synchronize pre-commit with constraints (black)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.10.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
This updates the `black` version in `pre-commit` hooks to `24.10.0` to match what is currently in `constraints.txt` (https://github.com/undertale-re/undertale/blob/main/constraints.txt#L27).