### PR TITLE
fix: update model pipelines after datatrove port

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,61 @@ available in the cache directory, you can do something like:
 ```python
 from undertale.datasets import humanevalx
 
-dataset = humanevalx.HumanEvalXCompiledDisassembled.fetch()
+dataset = humanevalx.HumanEvalX.fetch()
 
 ...
+```
+
+### Models
+
+#### Tokenizer Training
+
+```bash
+python -m undertale.models.item.tokenizer \
+    undertale.datasets.humanevalx:HumanEvalX \
+    -o item.tokenizer.json
+```
+
+#### Masked Language Modeling Pre-Training
+
+```bash
+# masked language modeling pre-training
+python -m undertale.models.item.pretrain-maskedlm \
+    undertale.datasets.humanevalx:HumanEvalX \
+    -t item.tokenizer.json \
+    -o pretrain-maskedlm
+```
+
+#### Contrastive Embedding Fine-Tuning
+
+```bash
+python -m undertale.models.item.finetune-embedding \
+    <dataset-tbd> \
+    -t item.tokenizer.json \
+    -m pretrain-maskedlm/9 \
+    -o finetune-embedding
+```
+
+#### Masked Language Modeling Inference
+
+**Warning: this output is pretty bad right now with only the small dataset - it should get better once we can start training with larger datasets.**
+
+```bash
+python -m undertale.models.item.infer-maskedlm \
+    -t item.tokenizer.json \
+    -m pretrain-maskedlm/9 \
+    "add eax, [MASK]"
+```
+
+#### Summarization Inference
+
+**Warning: this still uses an untrained code-language connector, the output will be gibberish, but it proves that everything is wired up correctly.**
+
+```bash
+python -m undertale.models.item.infer-summarization \
+    -t item.tokenizer.json \
+    -m finetune-embedding/9 \
+    "add eax, ebx\nxor ecx, ecx"
 ```
 
 ## Contributing

--- a/undertale/datasets/base.py
+++ b/undertale/datasets/base.py
@@ -157,7 +157,7 @@ class Dataset(metaclass=ABCMeta):
 
         logger.debug(f"loading dataset from {path!r}")
 
-        return datasets.load_dataset(path)
+        return datasets.load_dataset(path, split="train")
 
     @staticmethod
     def store(dataset: datasets.Dataset, path: str) -> None:

--- a/undertale/datasets/utils.py
+++ b/undertale/datasets/utils.py
@@ -1,7 +1,7 @@
 import importlib
 
 
-def from_specifier(specifier: str, schema=None):
+def from_specifier(specifier: str):
     """Fetch a dataset from a specifier string.
 
     This both identifies the dataset class and loads it by calling
@@ -10,8 +10,6 @@ def from_specifier(specifier: str, schema=None):
     Arguments:
         specifier: The module path and dataset class name to load (format:
             `{module.path}:{DatasetClass}`)
-        schema: If provided, validate that the loaded dataset follows this
-            schema.
 
     Returns:
         The requested dataset.
@@ -41,13 +39,9 @@ def from_specifier(specifier: str, schema=None):
     dataset_class = getattr(module, class_name)
 
     try:
-        dataset = dataset_class.fetch()
+        dataset = dataset_class().fetch()
     except Exception as e:
         raise ValueError(f"failed to load {class_name}: {e}")
-
-    if schema:
-        if not issubclass(dataset.schema, schema):
-            raise ValueError(f"unsupported dataset {class_name}: invalid schema")
 
     return dataset
 

--- a/undertale/models/item/finetune-embedding.py
+++ b/undertale/models/item/finetune-embedding.py
@@ -78,9 +78,7 @@ if __name__ == "__main__":
         model = model.from_pretrained(arguments.checkpoint, local_files_only=True)
 
     try:
-        dataset = datasets.from_specifier(
-            arguments.dataset, schema=datasets.schema.Function
-        )
+        dataset = datasets.from_specifier(arguments.dataset)
     except ValueError as e:
         logger.critical(e)
         exit(1)

--- a/undertale/models/item/pretrain-maskedlm.py
+++ b/undertale/models/item/pretrain-maskedlm.py
@@ -74,9 +74,7 @@ if __name__ == "__main__":
         model = model.from_pretrained(arguments.checkpoint, local_files_only=True)
 
     try:
-        dataset = datasets.from_specifier(
-            arguments.dataset, schema=datasets.schema.Function
-        )
+        dataset = datasets.from_specifier(arguments.dataset)
     except ValueError as e:
         logger.critical(e)
         exit(1)

--- a/undertale/models/item/tokenizer.py
+++ b/undertale/models/item/tokenizer.py
@@ -226,9 +226,7 @@ if __name__ == "__main__":
     )
 
     try:
-        dataset = datasets.from_specifier(
-            arguments.dataset, schema=datasets.schema.Function
-        )
+        dataset = datasets.from_specifier(arguments.dataset)
     except ValueError as e:
         logger.critical(e)
         exit(1)


### PR DESCRIPTION
- updates the model training pipelines to work after the datatrove port
- adds documentation for running them to the README

> [!Warning]
> This is not finished yet - @Swashbuckler1 is still looking into updating pretokenization for R2 (rizin). If you want to make the steps in the README work - you need to build the HumanEvalX dataset with the CapstoneDisassembler, not the GhidraDisassembler.

CC: @ashokk01824 