### PR TITLE
feat: Parsing binja disassembly tokens into mnemonic-operand form

### DIFF
--- a/undertale/datasets/humanevalx.py
+++ b/undertale/datasets/humanevalx.py
@@ -11,7 +11,7 @@ from datatrove.pipeline.readers import JsonlReader
 
 from .base import Dataset, main
 from .pipeline.compilers import CppCompiler
-from .pipeline.disassemblers import GhidraDisassembler
+from .pipeline.segmenters import BinaryNinjaFunctionSegmenter
 
 
 def adapt_humanevalx_from_raw(
@@ -33,7 +33,7 @@ class HumanEvalX(Dataset):
                 adapter=adapt_humanevalx_from_raw,
             ),
             CppCompiler(),
-            GhidraDisassembler(),
+            BinaryNinjaFunctionSegmenter(),
         ]
         steps.extend(writer)
 

--- a/undertale/datasets/pipeline/segmenters/binaryninja.py
+++ b/undertale/datasets/pipeline/segmenters/binaryninja.py
@@ -43,7 +43,7 @@ class BinaryNinjaFunctionSegmenter(PipelineStep):
         ]
 
         SKIP_TOKENS = [
-            InstructionTextTokenType.AnnotationToken,
+            InstructionTextTokenType.StackVariableToken,
             InstructionTextTokenType.TagToken,
         ]
 
@@ -91,9 +91,8 @@ class BinaryNinjaFunctionSegmenter(PipelineStep):
                             if token.type not in SKIP_TOKENS
                         )
                         disasm_str = " ".join(disasm_str.strip().split())
-                        if "pop" in disasm_str:
-                            print(disasm_str)
-                            # breakpoint()
+                        if "Does" in disasm_str:  # { Does not return }
+                            continue
                         if any("{" in token.text for token in line.tokens):
                             disasm_str = remove_braces(disasm_str)
                         if "sub_0" in disasm_str:

--- a/undertale/datasets/pipeline/segmenters/binaryninja.py
+++ b/undertale/datasets/pipeline/segmenters/binaryninja.py
@@ -22,12 +22,17 @@ class BinaryNinjaFunctionSegmenter(PipelineStep):
         """"""
 
         import pickle
+        import re
 
         import binaryninja
         import networkx as nx
         from binaryninja import SymbolType
         from binaryninja.enums import InstructionTextTokenType
         from datatrove.data import Document
+
+        def remove_braces(text):
+            # Matches ' {' followed by any characters (non-greedy) until the next '}'
+            return re.sub(r" \{.*?\}", "", text)
 
         SKIP_TYPES = [
             SymbolType.ImportedFunctionSymbol,
@@ -39,7 +44,7 @@ class BinaryNinjaFunctionSegmenter(PipelineStep):
 
         SKIP_TOKENS = [
             InstructionTextTokenType.AnnotationToken,
-            InstructionTextTokenType.StackVariableToken,
+            InstructionTextTokenType.TagToken,
         ]
 
         SYMBOL_TOKENS = [
@@ -86,6 +91,25 @@ class BinaryNinjaFunctionSegmenter(PipelineStep):
                             if token.type not in SKIP_TOKENS
                         )
                         disasm_str = " ".join(disasm_str.strip().split())
+                        if "pop" in disasm_str:
+                            print(disasm_str)
+                            # breakpoint()
+                        if any("{" in token.text for token in line.tokens):
+                            disasm_str = remove_braces(disasm_str)
+                        if "sub_0" in disasm_str:
+                            idx = next(
+                                (
+                                    i
+                                    for i, token in enumerate(line.tokens)
+                                    if token.text == "sub_0"
+                                ),
+                                -1,
+                            )
+                            disasm_str = disasm_str.replace(
+                                "sub_0", str(line.tokens[idx].value)
+                            )
+                        if "retn" in disasm_str:
+                            disasm_str = disasm_str[: disasm_str.find("n")]
                         if disasm_str != "":
                             block_disassembly.append(disasm_str)
                     block_disassembly = "\n".join(block_disassembly)


### PR DESCRIPTION
Lots of extraneous information in binja disassembly that I thought I was handling correctly by just skipping those tokens when I first made this pipelinestep. I discovered some edge cases when dealing with #54 .

```
xor eax, eax {sub_0} where sub_0 is CodeSymbolToken
mov qword [rbp-0xb0 {var_b8}], sub_0 where var_b8 is a StackVariableToken and sub_0 is a CodeSymbolToken
```
When skipping PossibleAddressToken:
```
sub rsp, 
cmp qword[rbp-0xa0], 
add rax, 
cmp rax,
```
When keeping:
```
mov byte [rbp-0x90], al0x19 
xor eax, 0x420x69 
mov rdi, rax0x427f
```
Fixed stuff like this in this PR.