### PR TITLE
fix: pretokenization of zero-operand instructions

### DIFF
--- a/undertale/models/item/tokenizer.py
+++ b/undertale/models/item/tokenizer.py
@@ -52,14 +52,10 @@ def pretokenize(disassembly: str) -> str:
         split = instruction.split(" ", maxsplit=1)
 
         # Hardware lock instruction prefix (e.g., 'xrelease lock add ...')
-        if split[0] in ["xacquire", "xrelease"]:
-            assert len(split) == 2
-            prefix, remainder = split
-            pretokens.append(prefix)
-            split = remainder.split(" ", maxsplit=1)
-
-        # Instruction prefix (e.g., 'lock add ...')
+        # or Instruction prefix (e.g., 'lock add ...').
         if split[0] in [
+            "xacquire",
+            "xrelease",
             "lock",
             "bnd",
             "notrack",
@@ -76,7 +72,7 @@ def pretokenize(disassembly: str) -> str:
 
         # Instruction without operands (e.g., `ret`).
         if len(split) == 1:
-            pretokens.append(split[0])
+            pretokens.extend([split[0], TOKEN_NEXT])
             continue
         else:
             mnemonic, operands = split
@@ -113,7 +109,7 @@ def pretokenize(disassembly: str) -> str:
 
                 pretokens.append("[")
 
-                # Base, offset, multiplier syntax
+                # Base, offset, multiplier syntax.
                 split = re.split(r"(\+|-|\*)", operand)
                 split = [o.strip() for o in split]
 


### PR DESCRIPTION
# Description
During pretokenization, zero-operand instructions were not followed by a `[NEXT]` token to mark the end of the instruction. As a result, the pretokenizer incorrectly merged them with the subsequent instruction.

## Changes Include
* Fixed the pretokenization bug.
* Refactored instruction prefix handling to eliminate duplicate code logic.

---

### Before
```pop rbx
 pop rbp
 pop r12 
 ret xor ebx ebx  ❌
 mov rdx r12
```
### After
```
 pop rbp 
 pop r12 
 ret ✅
 xor ebx ebx
 mov rdx r12
```

> [!NOTE] 
> This output is the result after replacing the `[NEXT]` token with a newline `\n`.
