### PR TITLE
build: add offline dependency download script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ CLAUDE.md
 *.err
 *.tfevents.*
 *.ckpt
+*.whl
 hparams.yaml
 
 *.DS_Store

--- a/scripts/wheelhouse.sh
+++ b/scripts/wheelhouse.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+download() {
+    local NAME=$1
+    local PLATFORM=$2
+    local OUTPUT=$3
+
+    echo "[ ] downloading $NAME wheels"
+
+    pip download . -c constraints.txt -d $OUTPUT \
+        --platform $PLATFORM \
+        --only-binary=:all:
+
+
+    if [ $? -ne 0 ]; then
+        echo "[-] downloading $NAME wheels failed"
+        exit $?
+    fi
+
+    echo "[+] downloaded $NAME wheels"
+}
+
+# Execute from the repo root, relative to this script.
+cd "$(dirname "$0")/.."
+
+# Local setup.
+OUTPUT="$(pwd)/vendor"
+
+# Download wheels.
+echo "[ ] building wheelhouse at $OUTPUT"
+
+download "Linux" "manylinux_2_17_x86_64 --platform manylinux_2_28_x86_64" $OUTPUT
+download "MacOS" "macosx_12_0_arm64" $OUTPUT
+download "Windows" "win_amd64" $OUTPUT
+
+echo "[+] wheelhouse complete at $OUTPUT"

--- a/scripts/wheelhouse.sh
+++ b/scripts/wheelhouse.sh
@@ -27,10 +27,10 @@ cd "$(dirname "$0")/.."
 OUTPUT="$(pwd)/vendor"
 
 # Download wheels.
-echo "[ ] building wheelhouse at $OUTPUT"
+echo "[ ] downloading dependencies to $OUTPUT"
 
 download "Linux" "manylinux_2_17_x86_64 --platform manylinux_2_28_x86_64" $OUTPUT
 download "MacOS" "macosx_12_0_arm64" $OUTPUT
 download "Windows" "win_amd64" $OUTPUT
 
-echo "[+] wheelhouse complete at $OUTPUT"
+echo "[+] dependency download complete at $OUTPUT"


### PR DESCRIPTION
- adds `scripts/wheelhouse.sh` to download python dependencies for offline install