### PR TITLE
feat[inference-server]: CLI `submit`, `delete` commands, UI delete button

### DIFF
--- a/extras/inference-frontend/package.json
+++ b/extras/inference-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "undertale-frontend",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "ng": "ng",
     "prebuild": "node scripts/set-version.mjs",

--- a/extras/inference-frontend/src/app/core/models/auth.model.ts
+++ b/extras/inference-frontend/src/app/core/models/auth.model.ts
@@ -5,4 +5,5 @@ export interface Credentials {
 
 export interface TokenResponse {
   token: string;
+  admin: boolean;
 }

--- a/extras/inference-frontend/src/app/core/services/auth.service.ts
+++ b/extras/inference-frontend/src/app/core/services/auth.service.ts
@@ -9,6 +9,7 @@ export class AuthService {
 
   readonly token = signal<string | null>(localStorage.getItem('token'));
   readonly username = signal<string | null>(this.decodeUsername(localStorage.getItem('token')));
+  readonly isAdmin = signal<boolean>(localStorage.getItem('admin') === 'true');
   readonly isAuthenticated = computed(() => this.token() !== null);
 
   private decodeUsername(token: string | null): string | null {
@@ -25,15 +26,19 @@ export class AuthService {
     return this.http.post<TokenResponse>('/api/login/', credentials).pipe(
       tap((response) => {
         localStorage.setItem('token', response.token);
+        localStorage.setItem('admin', String(response.admin));
         this.token.set(response.token);
         this.username.set(this.decodeUsername(response.token));
+        this.isAdmin.set(response.admin);
       }),
     );
   }
 
   logout(): void {
     localStorage.removeItem('token');
+    localStorage.removeItem('admin');
     this.token.set(null);
     this.username.set(null);
+    this.isAdmin.set(false);
   }
 }

--- a/extras/inference-frontend/src/app/features/maskedlm/components/completion-detail/completion-detail.html
+++ b/extras/inference-frontend/src/app/features/maskedlm/components/completion-detail/completion-detail.html
@@ -4,7 +4,14 @@
       <div class="d-flex align-items-center gap-2">
         <span [class]="stateBadgeClass(c.state)">{{ stateLabel(c.state) }}</span>
       </div>
-      <small class="text-muted">{{ c.timestamp | date: 'medium' }}</small>
+      <div class="d-flex align-items-center gap-2">
+        <small class="text-muted">{{ c.timestamp | date: 'medium' }}</small>
+        @if (isAdmin()) {
+          <button type="button" class="btn btn-danger btn-sm" (click)="deleteCompletion()">
+            Delete
+          </button>
+        }
+      </div>
     </div>
 
     <div class="mb-3">
@@ -55,4 +62,13 @@
       </div>
     }
   </div>
+}
+
+@if (showDeleteConfirm()) {
+  <app-confirm-modal
+    message="Are you sure you want to delete this completion?"
+    confirmLabel="Delete"
+    (confirmed)="onDeleteConfirmed()"
+    (cancelled)="onDeleteCancelled()"
+  />
 }

--- a/extras/inference-frontend/src/app/features/maskedlm/components/completion-detail/completion-detail.ts
+++ b/extras/inference-frontend/src/app/features/maskedlm/components/completion-detail/completion-detail.ts
@@ -3,8 +3,10 @@ import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
+import { AuthService } from '../../../../core/services/auth.service';
 import { CompletionService } from '../../../../core/services/completion.service';
 import { stateBadgeClass, stateLabel } from '../../../../core/models/completion.model';
+import { ConfirmModal } from '../../../../shared/components/confirm-modal/confirm-modal';
 
 interface PendingFeedback {
   id: number;
@@ -14,14 +16,17 @@ interface PendingFeedback {
 
 @Component({
   selector: 'app-completion-detail',
-  imports: [FormsModule, DatePipe],
+  imports: [FormsModule, DatePipe, ConfirmModal],
   templateUrl: './completion-detail.html',
   styleUrl: './completion-detail.css',
 })
 export class CompletionDetail implements OnDestroy {
+  protected readonly auth = inject(AuthService);
   protected readonly completionService = inject(CompletionService);
 
   protected readonly completion = computed(() => this.completionService.selected());
+  protected readonly isAdmin = computed(() => this.auth.isAdmin());
+  protected showDeleteConfirm = signal(false);
   protected rating = signal<number | null>(null);
   protected comments = signal<string>('');
   protected showComments = computed(() => this.rating() !== null);
@@ -65,6 +70,20 @@ export class CompletionDetail implements OnDestroy {
       );
       this.pending = null;
     }
+  }
+
+  deleteCompletion(): void {
+    this.showDeleteConfirm.set(true);
+  }
+
+  onDeleteConfirmed(): void {
+    const c = this.completion();
+    if (c) this.completionService.delete(c.id);
+    this.showDeleteConfirm.set(false);
+  }
+
+  onDeleteCancelled(): void {
+    this.showDeleteConfirm.set(false);
   }
 
   setRating(index: number): void {

--- a/extras/inference-frontend/src/app/features/maskedlm/components/sidebar/sidebar.ts
+++ b/extras/inference-frontend/src/app/features/maskedlm/components/sidebar/sidebar.ts
@@ -16,10 +16,7 @@ export class Sidebar {
 
   protected search = signal('');
 
-  protected readonly isAdmin = computed(() => {
-    const username = this.auth.username();
-    return this.completionService.completions().some((c) => c.username !== username);
-  });
+  protected readonly isAdmin = computed(() => this.auth.isAdmin());
 
   protected readonly filtered = computed(() => {
     const query = this.search().toLowerCase().trim();

--- a/extras/inference-server/README.md
+++ b/extras/inference-server/README.md
@@ -99,12 +99,22 @@ inference purge
 inference users
 inference users --sorted          # sort by completion count (descending)
 
+# Force authentication of a given user by username
+inference authenticate username
+
 # List completions (default limit: 10)
 inference completions
 inference completions --user <username>
 inference completions --date YYYY-MM-DD
 inference completions --input <substring>
 inference completions --limit <n>
+
+# Submit a completion from the CLI
+inference submit -u username "xor rax [MASK]"
+
+# Delete a completion
+inference delete 42
+inference delete 42 --confirm
 
 # Export completions to Parquet
 inference export completions.parquet

--- a/extras/inference-server/inference/__init__.py
+++ b/extras/inference-server/inference/__init__.py
@@ -3,6 +3,6 @@ __author__ = "MIT Lincoln Laboratory"
 __description__ = "Undertale Inference Server"
 __copyright__ = f"2025, {__author__}"
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 __doc__ = f"{__title__}: {__description__}."

--- a/extras/inference-server/inference/api.py
+++ b/extras/inference-server/inference/api.py
@@ -142,7 +142,9 @@ def create_app() -> Flask:
             g.session.add(user)
             g.session.commit()
 
-        return jsonify({"token": create_access_token(identity=username)})
+        return jsonify(
+            {"token": create_access_token(identity=username), "admin": user.admin}
+        )
 
     @application.route("/")
     @jwt_required()

--- a/extras/inference-server/inference/cli/__init__.py
+++ b/extras/inference-server/inference/cli/__init__.py
@@ -2,6 +2,7 @@ from .admin import Admin
 from .authenticate import Authenticate
 from .base import Command, build_parser
 from .completions import Completions
+from .delete import Delete
 from .destroy import Destroy
 from .export import Export
 from .initialize import Initialize
@@ -18,6 +19,7 @@ __commands__ = [
     Admin,
     Authenticate,
     Purge,
+    Delete,
     Users,
     Completions,
     Submit,

--- a/extras/inference-server/inference/cli/__init__.py
+++ b/extras/inference-server/inference/cli/__init__.py
@@ -7,6 +7,7 @@ from .export import Export
 from .initialize import Initialize
 from .migrate import Migrate
 from .purge import Purge
+from .submit import Submit
 from .users import Users
 from .worker import Worker
 
@@ -19,6 +20,7 @@ __commands__ = [
     Purge,
     Users,
     Completions,
+    Submit,
     Export,
     Worker,
 ]

--- a/extras/inference-server/inference/cli/delete.py
+++ b/extras/inference-server/inference/cli/delete.py
@@ -1,0 +1,43 @@
+from sqlalchemy.orm import Session
+
+from ..exceptions import CommandError
+from ..models import Completion, connect
+from ..settings import fetch as fetch_settings
+from .base import Command
+
+PROMPT = "Delete completion {id}? [y/N]: "
+
+
+class Delete(Command):
+    name = "delete"
+    help = "delete a single completion by ID"
+
+    def add_arguments(self, parser):
+        parser.add_argument("id", type=int, help="ID of the completion to delete")
+        parser.add_argument(
+            "-c",
+            "--confirm",
+            action="store_true",
+            help="skip the interactive confirmation prompt",
+        )
+
+    def handle(self, arguments):
+        settings = fetch_settings()
+        engine = connect(settings["database"])
+
+        with Session(engine) as session:
+            completion = session.get(Completion, arguments.id)
+
+            if completion is None:
+                raise CommandError(f"completion with ID {arguments.id} does not exist")
+
+            if not arguments.confirm:
+                response = input(PROMPT.format(id=arguments.id))
+                if response.strip().lower() != "y":
+                    print("Aborted.")
+                    return
+
+            session.delete(completion)
+            session.commit()
+
+        print(f"Deleted completion {arguments.id}.")

--- a/extras/inference-server/inference/cli/purge.py
+++ b/extras/inference-server/inference/cli/purge.py
@@ -19,6 +19,7 @@ class Purge(Command):
 
     def add_arguments(self, parser):
         parser.add_argument(
+            "-c",
             "--confirm",
             action="store_true",
             help="skip the interactive confirmation prompt",

--- a/extras/inference-server/inference/cli/submit.py
+++ b/extras/inference-server/inference/cli/submit.py
@@ -1,0 +1,50 @@
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from ..exceptions import CommandError
+from ..models import Completion, CompletionState, CompletionType, User, connect
+from ..settings import fetch as fetch_settings
+from .base import Command
+
+
+class Submit(Command):
+    name = "submit"
+    help = "submit a completion to be consumed by a worker"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-u",
+            "--username",
+            required=True,
+            help="username to submit the completion as",
+        )
+        parser.add_argument("input", help="the input text to submit")
+
+    def handle(self, arguments):
+        settings = fetch_settings()
+        engine = connect(settings["database"])
+
+        with Session(engine) as session:
+            user = (
+                session.query(User).filter(User.username == arguments.username).first()
+            )
+
+            if user is None:
+                raise CommandError(f"user '{arguments.username}' does not exist")
+
+            completion = Completion(
+                user=user,
+                type=int(CompletionType.MaskedLM),
+                input=arguments.input,
+                timestamp=datetime.now(UTC),
+                state=int(CompletionState.queued),
+            )
+            session.add(completion)
+            session.commit()
+
+            username = completion.user.username
+            timestamp = completion.timestamp.isoformat()
+            print("Submitted:")
+            print(f"  \033[1m{username}\033[0m  {completion.id}  {timestamp}")
+            print(f"    input: {completion.input}")


### PR DESCRIPTION
- `inference-server` adds `submit` CLI command allowing submission without the UI
- `inference-server` adds `delete` CLI command allowing completion deletion
- `inference-frontend` adds Delete button on completion detail page, visible to admins only
- makes admin detection more explicit instead of inferring from completion listing
