### PR TITLE
feat: dataset shuffling utility

### DIFF
--- a/docs/usage/datasets.rst
+++ b/docs/usage/datasets.rst
@@ -161,6 +161,42 @@ use the ``repartition`` utility.
 
 Exactly one of ``--chunks`` or ``--size`` must be specified.
 
+Shuffle a Dataset
+^^^^^^^^^^^^^^^^^
+
+To randomly shuffle the rows of a dataset, use the shuffle utility.
+
+.. code-block:: bash
+
+    python -m undertale.utils.datasets.shuffle \
+        humaneval-x/ \
+        humaneval-x-shuffled
+
+Use ``--seed`` for a reproducible shuffle:
+
+.. code-block:: bash
+
+    python -m undertale.utils.datasets.shuffle \
+        humaneval-x/ \
+        humaneval-x-shuffled \
+        --seed 42
+
+The shuffle is applied within each partition. To approximate a global shuffle,
+use ``--partitions`` to merge the dataset into fewer, larger partitions before
+shuffling. The output will be restored to the original number of partitions.
+
+.. code-block:: bash
+
+    # Merge into 4 partitions before shuffling, then restore original count.
+    python -m undertale.utils.datasets.shuffle \
+        humaneval-x/ \
+        humaneval-x-shuffled \
+        --partitions 4
+
+Fewer partitions means rows are drawn from a larger pool during each shuffle
+pass, producing a more globally mixed result at the cost of higher memory usage
+per worker.
+
 Drop or Keep Columns
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -55,6 +55,7 @@ from undertale.pipeline.parquet import (
     Keep,
     Rename,
     Repartition,
+    Shuffle,
     modify_parquet,
 )
 from undertale.pipeline.tarfile import extract_tarfile
@@ -1047,6 +1048,37 @@ class TestPipelineParquet(TestCase):
 
         self.assertEqual(loaded["id"].dtype, "float32")
         self.assertEqual(loaded["value"].dtype, "int64")
+
+    def test_parquet_shuffle_simple(self):
+        working = TemporaryDirectory()
+        dataset = self.mock_dataset(working, "dataset", size=20)
+
+        output = join(working.name, "shuffled")
+        modify_parquet(dataset, output, [Shuffle(seed=42)])
+
+        loaded = read_parquet(output)
+
+        self.assertEqual(set(loaded["id"]), set(range(20)))
+        self.assertEqual(len(loaded), 20)
+
+    def test_parquet_shuffle_seed(self):
+        working = TemporaryDirectory()
+        dataset = self.mock_dataset(working, "dataset", size=20)
+
+        output_a = join(working.name, "shuffled_a")
+        output_b = join(working.name, "shuffled_b")
+        output_c = join(working.name, "shuffled_c")
+
+        modify_parquet(dataset, output_a, [Shuffle(seed=42)])
+        modify_parquet(dataset, output_b, [Shuffle(seed=42)])
+        modify_parquet(dataset, output_c, [Shuffle(seed=99)])
+
+        loaded_a = read_parquet(output_a)
+        loaded_b = read_parquet(output_b)
+        loaded_c = read_parquet(output_c)
+
+        self.assertEqual(list(loaded_a["id"]), list(loaded_b["id"]))
+        self.assertNotEqual(list(loaded_a["id"]), list(loaded_c["id"]))
 
 
 class TestPipelineCpp(TestCase):

--- a/undertale/pipeline/parquet.py
+++ b/undertale/pipeline/parquet.py
@@ -139,6 +139,30 @@ class Rename(ParquetOperation):
         return frame.rename(columns=self.mapping)
 
 
+class Shuffle(ParquetOperation):
+    """Randomly shuffle rows in the dataset.
+
+    Note:
+        This is a per-partition shuffle. In most cases, this is good enough,
+        but if you want to get closer to a global shuffle, consider
+        repartitioning to a smaller number of shards before shuffling. For
+        example, repartitioning to a single shard is equivalent to global
+        shuffle, but requires the full dataset to fit within the memory of a
+        single worker.
+
+    Arguments:
+        seed: Random seed for reproducibility. If ``None``, the shuffle is
+            non-deterministic.
+    """
+
+    def __init__(self, seed: Optional[int] = 42):
+        self.seed = seed
+
+    def __call__(self, frame: DataFrame) -> DataFrame:
+        logger.info("shuffling dataset")
+        return frame.sample(frac=1, random_state=self.seed)
+
+
 class Cast(ParquetOperation):
     """Cast column types in the dataset.
 
@@ -258,6 +282,7 @@ __all__ = [
     "Drop",
     "Keep",
     "Rename",
+    "Shuffle",
     "Cast",
     "Repartition",
     "modify_parquet",

--- a/undertale/utils/datasets/shuffle.py
+++ b/undertale/utils/datasets/shuffle.py
@@ -1,0 +1,64 @@
+"""Randomly shuffle rows in a parquet dataset."""
+
+from dask.dataframe import read_parquet as dask_read_parquet
+
+from undertale.logging import get_logger
+from undertale.parsers import DatasetArgumentParser
+from undertale.pipeline import Client, Cluster, flush
+from undertale.pipeline.parquet import Repartition, Shuffle, modify_parquet
+from undertale.utils import assert_path_exists
+
+logger = get_logger(__name__)
+
+
+if __name__ == "__main__":
+    parser = DatasetArgumentParser(description="shuffle rows in a parquet dataset")
+
+    parser.add_argument(
+        "-s",
+        "--seed",
+        type=int,
+        default=42,
+        metavar="SEED",
+        help="random seed for reproducibility",
+    )
+
+    parser.add_argument(
+        "-n",
+        "--partitions",
+        type=int,
+        default=None,
+        metavar="N",
+        help="if provided, re-partition to N chunks before shuffling for a closer approximation to a global shuffle",
+    )
+
+    arguments = parser.parse_args()
+    parser.setup(arguments)
+
+    with (
+        Cluster(type=arguments.cluster, parallelism=arguments.parallelism) as cluster,
+        Client(cluster) as client,
+    ):
+        logger.info("shuffling dataset")
+
+        source = assert_path_exists(arguments.input)
+
+        if arguments.partitions is not None:
+            original = dask_read_parquet(source).npartitions
+            operations = [
+                Repartition(chunks=arguments.partitions),
+                Shuffle(seed=arguments.seed),
+                Repartition(chunks=original),
+            ]
+        else:
+            operations = [Shuffle(seed=arguments.seed)]
+
+        modify_parquet(
+            input=source,
+            output=arguments.output,
+            operations=operations,
+        )
+
+        flush(client)
+
+    logger.info("shuffle complete")


### PR DESCRIPTION
- adds a `Shuffle` `ParquetOperation` that does a per-partition random row shuffle
- adds a dataset shuffle utility `python -m undertale.utils.datasets.shuffle ...` that calls it
- approximates global shuffle with a transient repartition operation, controlled by the user (`-n/--partitions`)
- adds documentation for the above
- adds unit tests for the above