### PR TITLE
ci: added Claude workflows

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   Respond:
-    if: contains(github.event.comment.body, '@claude')
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -1,0 +1,36 @@
+name: Claude Mentions
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
+
+jobs:
+  Respond:
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --disallowedTools Bash,Edit,Write
+            --max-turns 10
+            --append-system-prompt "You are a code reviewer and technical assistant for this repository.
+            You may answer questions, provide feedback, and post formal GitHub PR reviews (with inline
+            comments and APPROVE/REQUEST_CHANGES/COMMENT state) when asked to review or re-review a PR.
+            You must NOT implement changes, push code, create or modify files, create branches, or open
+            pull requests under any circumstances. When responding to an issue mention, provide feedback
+            or answer the question — do not implement anything."

--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,47 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+  actions: read
+
+jobs:
+  Review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--disallowedTools Bash,Edit,Write --max-turns 10"
+          prompt: |
+            Review this pull request and submit a formal GitHub PR review (not a plain comment).
+
+            Your review must:
+            1. Post inline comments on specific changed lines where you have concrete, targeted feedback
+            2. Include an overall summary in the review body covering: what the PR does, key concerns, and a final verdict
+            3. Set the review state to one of:
+               - APPROVE — if the changes are correct, safe, and production-ready
+               - REQUEST_CHANGES — if there are bugs, security issues, or convention violations that must be fixed first
+               - COMMENT — if you have observations but no blocking objection
+
+            Focus on:
+            - Correctness and logic errors
+            - Security vulnerabilities
+            - Adherence to project conventions (see CLAUDE.md: Black, isort, Google docstrings, type hints, pipeline idempotency pattern)
+            - Type safety (mypy compliance)
+            - Test coverage for new functionality
+            - Performance concerns
+
+            Do not comment on formatting, import order, or anything already enforced by pre-commit CI.
+            Do not implement any changes yourself.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-CLAUDE.md
-
 *.swp
 *.pyc
 *.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+Undertale is a research project for training LLMs on binary program
+understanding. It includes dataset build pipelines, custom transformer models,
+evaluation infrastructure, and integrations with external products.
+
+## Architecture
+
+- `undertale/` — installable library (schema, parsers, pipeline utilities, models)
+  - `pipeline/` — per-format stage helpers (binary, parquet, dask, json, tarfile, zip, cpp)
+  - `models/` — transformer variants (maskedlm, classification, summarization, tuning)
+  - `schema.py` — Pandera DataFrame schemas; all pipeline outputs must validate against one
+  - `parsers.py` — `DatasetArgumentParser` / `ModelArgumentParser` for pipeline entry points
+- `pipelines/` — standalone runnable scripts (not part of the library)
+  - `datasets/` — data ingestion pipelines
+  - `models/` — training, fine-tuning, inference scripts; paired `.slurm` files for HPC runs
+- `extras/` — standalone sub-projects (inference-frontend, inference-server)
+- `scripts/` — one-off migration scripts (datatrove-legacy)
+- `environments/` — `.env` templates; source one before running pipelines
+
+### Notes
+
+#### Pipeline Stages
+- **Pipeline Idempotency**: stages use `get_or_create_directory(output)` which
+  returns `(path, created)`. If `not created`, the stage should skip processing
+  and return existing outputs. All new pipeline stages must follow this
+  pattern.
+
+## Commands
+
+```bash
+# Run all tests
+python tests/unit.py --verbose
+
+# Run a specific test case
+python tests/unit.py --verbose TestPipelineBinary
+
+# Pre-commit hooks (linting/formatting).
+pre-commit run -a
+
+# Build documentation
+sphinx-build -b html docs build/documentation/
+```
+
+## Workflow
+
+Always run `pre-commit run -a` after any code changes before reporting a task
+complete. Hooks auto-fix formatting (black, isort).
+
+## Conventions
+
+- **Code style**: Black formatter, isort with `profile = "black"`.
+- **Docstrings**: Google style.
+- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/) —
+  `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, etc.
+- **Branching**: Feature branches only; squash-merge to `main`.
+- **Type hints**: Used throughout; mypy is enforced in CI.
+
+## Style
+
+- Prefer variable/function/class names that are complete words (e.g.,
+  `position` instead of `pos`).
+- Light preference against multi-word variable/function/class names. Ignore
+  this preference if using a single word would result in too much ambiguity and
+  make reading code difficult.

--- a/extras/inference-frontend/CLAUDE.md
+++ b/extras/inference-frontend/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this part of the repository.
+
+## Project Overview
+
+Undertale: Inference Frontend is a UI web frontend for the Undertale inference
+server REST API. For more details on the API - check out that project's
+CLAUDE.md or README.md.
+
+## Commands
+
+```bash
+# The Angular CLI is not installed globally, run through npx.
+npx ng ...
+
+# Pre-commit hooks (linting/formatting).
+pre-commit run -a
+
+# Prettier for automatic formatting.
+npx prettier -w ./
+```
+
+## Conventions
+
+All documentation is in README.md. Make sure you keep this up to date.


### PR DESCRIPTION
- adds a Claude Actions workflow to review every new PR onto `main`
- adds a Claude Actions workflow to respond to mentions of @claude
- adds `CLAUDE.md` - we can iterate on this
- workflows are comment-only - they cannot open PRs or commit code directly, developers will still have to do that via `claude` CLI