### PR TITLE
feat[inference-server]: make authentication optional

### DIFF
--- a/extras/inference-server/README.md
+++ b/extras/inference-server/README.md
@@ -41,6 +41,10 @@ Migrate the database:
 inference migrate
 ```
 
+#### Authenticated Systemd Service
+
+Configure the settings to point to your LDAP instance for authentication.
+
 Install the API systemd service using the example as a reference:
 
 ```bash
@@ -63,9 +67,26 @@ cp examples/undertale-inference-worker.service /etc/systemd/system/
 systemctl enable --now undertale-inference-worker
 ```
 
+#### Unauthenticated Local Service
+
+Authentication may be disabled for simple, co-located inference service
+deployments (e.g., `authentication = False` in the configuration).
+
+Start the inference server bound to e.g., a Unix socket:
+
+```bash
+gunicorn --bind unix:./undertale-inference.sock inference.api:app
+```
+
+Start the inference worker(s):
+
+```bash
+inference worker --parallelism 2
+```
+
 ## Usage
 
-### Systemd Service
+### Authenticated Systemd Service
 
 Use `systemctl` to manage the services:
 
@@ -100,6 +121,7 @@ inference users
 inference users --sorted          # sort by completion count (descending)
 
 # Force authentication of a given user by username
+# (errors when authentication is disabled)
 inference authenticate username
 
 # List completions (default limit: 10)
@@ -140,12 +162,12 @@ conda env update -f environment.development.yml
 conda activate undertale
 ```
 
-You might also find the environment file `environment/development.env` useful
+You might also find the environment file `environments/development.env` useful
 for development purposes. This file sets environment variables for the project
 to a useful configuration for development. To activate it, run:
 
 ```bash
-source environment/development.env
+source environments/development.env
 ```
 
 ### Development Server

--- a/extras/inference-server/environments/development.env
+++ b/extras/inference-server/environments/development.env
@@ -1,1 +1,4 @@
 export UNDERTALE_WORKSPACE=.
+
+# Allow gunicorn workers to survive fork() on macOS; harmless elsewhere.
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES

--- a/extras/inference-server/inference/api.py
+++ b/extras/inference-server/inference/api.py
@@ -1,12 +1,13 @@
+import functools
 from datetime import UTC, datetime, timedelta
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional, ParamSpec, TypeVar
 
-from flask import Flask, abort, g, jsonify, request
+from flask import Flask, abort, current_app, g, jsonify, request
 from flask_jwt_extended import (
     JWTManager,
     create_access_token,
     get_jwt_identity,
-    jwt_required,
+    verify_jwt_in_request,
 )
 from ldap3 import AUTO_BIND_NONE, SIMPLE, Connection, Server
 from ldap3.core.exceptions import LDAPBindError, LDAPException
@@ -28,6 +29,26 @@ from .text import sanitize
 logger = get_logger(__name__)
 
 
+ANONYMOUS = "default"
+"""Username that all requests run as when authentication is disabled."""
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def authenticated(function: Callable[P, T]) -> Callable[P, T]:
+    """Require a valid JWT, unless authentication is disabled."""
+
+    @functools.wraps(function)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        if current_app.config["AUTHENTICATION"]:
+            verify_jwt_in_request()
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
 def require_fields(data: Optional[Dict], *fields: str) -> None:
     if data is None:
         abort(400)
@@ -38,6 +59,17 @@ def require_fields(data: Optional[Dict], *fields: str) -> None:
 
 
 def current_user(session: Session) -> User:
+    if not current_app.config["AUTHENTICATION"]:
+        user = session.query(User).filter_by(username=ANONYMOUS).first()
+        if user is None:
+            user = User(username=ANONYMOUS, admin=True)
+            session.add(user)
+            session.commit()
+        elif not user.admin:
+            user.admin = True
+            session.commit()
+        return user
+
     user = session.query(User).filter_by(username=get_jwt_identity()).first()
     if user is None:
         abort(401)
@@ -67,18 +99,25 @@ def create_app() -> Flask:
 
     settings = fetch_settings()
     application.config["ENGINE"] = connect(settings["database"])
-    application.config["JWT_SECRET_KEY"] = settings["jwtsecret"]
-    application.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(days=14)
-    application.config["LDAP_HOST"] = settings["ldaphost"]
-    application.config["LDAP_PORT"] = settings["ldapport"]
-    application.config["LDAP_DOMAIN"] = settings["ldapdomain"]
+    application.config["AUTHENTICATION"] = settings["authentication"]
 
-    if settings["jwtsecret"] == "secret":
+    if settings["authentication"]:
+        application.config["JWT_SECRET_KEY"] = settings["jwtsecret"]
+        application.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(days=14)
+        application.config["LDAP_HOST"] = settings["ldaphost"]
+        application.config["LDAP_PORT"] = settings["ldapport"]
+        application.config["LDAP_DOMAIN"] = settings["ldapdomain"]
+
+        if settings["jwtsecret"] == "secret":
+            logger.warning(
+                "JWTSecret is set to its default value; set a strong secret before deploying"
+            )
+
+        JWTManager(application)
+    else:
         logger.warning(
-            "JWTSecret is set to its default value; set a strong secret before deploying"
+            f"authentication is disabled; all requests run as admin user {ANONYMOUS!r}"
         )
-
-    JWTManager(application)
 
     @application.before_request
     def before_request():
@@ -108,6 +147,9 @@ def create_app() -> Flask:
 
     @application.route("/login/", methods=["POST"])
     def login():
+        if not application.config["AUTHENTICATION"]:
+            abort(404)
+
         data = request.get_json(silent=True)
         require_fields(data, "username", "password")
 
@@ -148,11 +190,12 @@ def create_app() -> Flask:
         )
 
     @application.route("/")
-    @jwt_required()
+    @authenticated
     def index():
         prefix = request.script_root.rstrip("/")
         return jsonify(
             {
+                "authentication": application.config["AUTHENTICATION"],
                 "endpoints": [
                     f"GET {prefix}/",
                     f"POST {prefix}/login/",
@@ -166,12 +209,12 @@ def create_app() -> Flask:
                     f"GET {prefix}/fnaming/completion/<id>/",
                     f"DELETE {prefix}/fnaming/completion/<id>/",
                     f"POST {prefix}/fnaming/completion/<id>/feedback/",
-                ]
+                ],
             }
         )
 
     @application.route("/maskedlm/completion/", methods=["GET"])
-    @jwt_required()
+    @authenticated
     def list_completions():
         user = current_user(g.session)
         query = (
@@ -185,7 +228,7 @@ def create_app() -> Flask:
         return jsonify([serialize_completion(c) for c in completions])
 
     @application.route("/maskedlm/completion/", methods=["POST"])
-    @jwt_required()
+    @authenticated
     def create_completion():
         data = request.get_json(silent=True)
         require_fields(data, "input")
@@ -207,7 +250,7 @@ def create_app() -> Flask:
         return jsonify(serialize_completion(completion)), 201
 
     @application.route("/maskedlm/completion/<int:completion_id>/", methods=["GET"])
-    @jwt_required()
+    @authenticated
     def get_completion(completion_id: int):
         user = current_user(g.session)
         completion = (
@@ -223,7 +266,7 @@ def create_app() -> Flask:
         return jsonify(serialize_completion(completion))
 
     @application.route("/maskedlm/completion/<int:completion_id>/", methods=["DELETE"])
-    @jwt_required()
+    @authenticated
     def delete_completion(completion_id: int):
         user = current_user(g.session)
         completion = (
@@ -246,7 +289,7 @@ def create_app() -> Flask:
     @application.route(
         "/maskedlm/completion/<int:completion_id>/feedback/", methods=["POST"]
     )
-    @jwt_required()
+    @authenticated
     def upsert_feedback(completion_id: int):
         user = current_user(g.session)
         completion = (
@@ -276,7 +319,7 @@ def create_app() -> Flask:
         return jsonify({"rating": completion.rating, "comments": completion.comments})
 
     @application.route("/fnaming/completion/", methods=["GET"])
-    @jwt_required()
+    @authenticated
     def list_namings():
         user = current_user(g.session)
         query = (
@@ -290,7 +333,7 @@ def create_app() -> Flask:
         return jsonify([serialize_completion(c) for c in completions])
 
     @application.route("/fnaming/completion/", methods=["POST"])
-    @jwt_required()
+    @authenticated
     def name_function():
         data = request.get_json(silent=True)
         require_fields(data, "input")
@@ -312,7 +355,7 @@ def create_app() -> Flask:
         return jsonify(serialize_completion(naming)), 201
 
     @application.route("/fnaming/completion/<int:completion_id>/", methods=["GET"])
-    @jwt_required()
+    @authenticated
     def get_naming(completion_id: int):
         user = current_user(g.session)
         naming = (
@@ -328,7 +371,7 @@ def create_app() -> Flask:
         return jsonify(serialize_completion(naming))
 
     @application.route("/fnaming/completion/<int:completion_id>/", methods=["DELETE"])
-    @jwt_required()
+    @authenticated
     def delete_naming(completion_id: int):
         user = current_user(g.session)
         naming = (
@@ -351,7 +394,7 @@ def create_app() -> Flask:
     @application.route(
         "/fnaming/completion/<int:completion_id>/feedback/", methods=["POST"]
     )
-    @jwt_required()
+    @authenticated
     def upsert_feedback_fnaming(completion_id: int):
         user = current_user(g.session)
         completion = (

--- a/extras/inference-server/inference/cli/authenticate.py
+++ b/extras/inference-server/inference/cli/authenticate.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 
+from ..exceptions import CommandError
 from ..models import User, connect
 from ..settings import fetch as fetch_settings
 from .base import Command
@@ -17,6 +18,12 @@ class Authenticate(Command):
         from flask_jwt_extended import JWTManager, create_access_token
 
         settings = fetch_settings()
+
+        if not settings["authentication"]:
+            raise CommandError(
+                "authentication is disabled; tokens are not required or supported"
+            )
+
         engine = connect(settings["database"])
 
         with Session(engine) as session:

--- a/extras/inference-server/inference/settings.py
+++ b/extras/inference-server/inference/settings.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from configparser import ConfigParser, NoOptionError
 from os.path import exists
 from secrets import token_hex
-from typing import Dict
+from typing import Any, Dict, Optional
 
 from .exceptions import ConfigurationError
 from .logging import get_logger
@@ -31,6 +31,12 @@ def get_settings_path() -> str:
 
 
 class Setting(ABC):
+    required: bool = True
+    """Whether this setting must be present in the settings file."""
+
+    fallback: Optional[str] = None
+    """The raw value assumed when an optional setting is absent."""
+
     @property
     @abstractmethod
     def key(self) -> str:
@@ -72,19 +78,38 @@ class FunctionNamingCheckpoint(Setting):
     default = "{workspace}/fnaming.ckpt"
 
 
+class Authentication(Setting):
+    key = "authentication"
+    default = "yes"
+    required = False
+    fallback = "yes"
+
+    def parse(self, value: str) -> bool:
+        states = ConfigParser.BOOLEAN_STATES
+        normalized = value.strip().lower()
+        if normalized not in states:
+            raise ConfigurationError(
+                f"invalid boolean value for 'authentication': {value!r}"
+            )
+        return states[normalized]
+
+
 class JWTSecret(Setting):
     key = "jwtsecret"
     default = token_hex(32)
+    required = False
 
 
 class LDAPHost(Setting):
     key = "ldaphost"
     default = "ad.example.com"
+    required = False
 
 
 class LDAPPort(Setting):
     key = "ldapport"
     default = "636"
+    required = False
 
     def parse(self, value: str) -> int:
         return int(value)
@@ -93,6 +118,7 @@ class LDAPPort(Setting):
 class LDAPDomain(Setting):
     key = "ldapdomain"
     default = "example.com"
+    required = False
 
 
 def initialize() -> None:
@@ -115,7 +141,7 @@ def initialize() -> None:
     logger.info(f"wrote initial configuration file to {path}")
 
 
-def fetch() -> Dict[str, str]:
+def fetch() -> Dict[str, Any]:
     """Fetch the current settings.
 
     Returns:
@@ -135,14 +161,25 @@ def fetch() -> Dict[str, str]:
             f"settings file {path} missing section {SETTINGS_SECTION!r}"
         )
 
-    settings = {}
+    settings: Dict[str, Any] = {}
     for setting in Setting.__subclasses__():
         s = setting()  # type: ignore
 
         try:
-            settings[s.key] = s.parse(parser.get(SETTINGS_SECTION, s.key))
+            value: Optional[str] = parser.get(SETTINGS_SECTION, s.key)
         except NoOptionError as e:
-            raise ConfigurationError(str(e))
+            if s.required:
+                raise ConfigurationError(str(e))
+            value = s.fallback
+
+        settings[s.key] = s.parse(value) if value is not None else None
+
+    if settings["authentication"]:
+        for key in ("jwtsecret", "ldaphost", "ldapport", "ldapdomain"):
+            if settings[key] is None:
+                raise ConfigurationError(
+                    f"setting {key!r} is required when authentication is enabled"
+                )
 
     return settings
 


### PR DESCRIPTION
- adds an `authentication` setting (default: `True`)
- adds README documentation for no-auth local deployment
- supports co-located inference service deployment scheme where auth is meaningless